### PR TITLE
Update RI Commission for Human Rights agency website link

### DIFF
--- a/src/data/legalResources.ts
+++ b/src/data/legalResources.ts
@@ -1588,7 +1588,7 @@ export const legalResourcesData: LegalResource[] = [
       {
         name: 'Rhode Island Commission for Human Rights',
         phone: '401-222-2661',
-        website: 'https://www.richr.ri.gov/',
+        website: 'http://www.richr.ri.gov/filecharge/index.php',
         filingInfo: 'File employment discrimination complaint within 1 year of violation. Commission investigates and enforces fair employment practices.'
       },
       {


### PR DESCRIPTION
- Changed government agency website from generic homepage to direct filing page
- Updated link to http://www.richr.ri.gov/filecharge/index.php
- Provides consistent access to filing instructions and intake forms
- Matches the resources section complaint filing link for better UX